### PR TITLE
Fix ClassCastException whenever a non-PlayerEntity drinks a potion

### DIFF
--- a/src/main/java/chronosacaria/mcda/mixin/enchantments/FoodReservesEnchantmentMixin.java
+++ b/src/main/java/chronosacaria/mcda/mixin/enchantments/FoodReservesEnchantmentMixin.java
@@ -28,6 +28,9 @@ public abstract class FoodReservesEnchantmentMixin {
 
     @Inject(method = "consumeItem", at = @At("TAIL"))
     public void onPotionUsed(CallbackInfo ci){
+        if (!((Object)this instanceof PlayerEntity))
+            return;
+
         PlayerEntity playerEntity = (PlayerEntity) (Object) this;
         if (playerEntity.isAlive()){
             List<StatusEffectInstance> potionEffects = PotionUtil.getPotionEffects(getMainHandStack());

--- a/src/main/java/chronosacaria/mcda/mixin/enchantments/PotionBarrierEnchantmentMixin.java
+++ b/src/main/java/chronosacaria/mcda/mixin/enchantments/PotionBarrierEnchantmentMixin.java
@@ -25,6 +25,9 @@ public abstract class PotionBarrierEnchantmentMixin {
 
     @Inject(method = "consumeItem", at = @At("TAIL"))
     public void onPotionBarrierPotionUsed(CallbackInfo ci) {
+        if (!((Object)this instanceof PlayerEntity))
+            return;
+
         PlayerEntity playerEntity = (PlayerEntity) (Object) this;
         if (playerEntity.isAlive()) {
             List<StatusEffectInstance> potionEffects = PotionUtil.getPotionEffects(getMainHandStack());

--- a/src/main/java/chronosacaria/mcda/mixin/enchantments/SurpriseGiftEnchantmentMixin.java
+++ b/src/main/java/chronosacaria/mcda/mixin/enchantments/SurpriseGiftEnchantmentMixin.java
@@ -28,6 +28,9 @@ public abstract class SurpriseGiftEnchantmentMixin {
 
     @Inject(method = "consumeItem", at = @At("TAIL"))
     public void onSurpriseGiftPotionUsed(CallbackInfo ci){
+        if (!((Object)this instanceof PlayerEntity))
+            return;
+
         PlayerEntity playerEntity = (PlayerEntity) (Object) this;
         if (playerEntity.isAlive()){
             List<StatusEffectInstance> potionEffects = PotionUtil.getPotionEffects(getMainHandStack());


### PR DESCRIPTION
The fix https://github.com/chronosacaria/MCDungeonsArmors/commit/6db966d7c7df2b44feeba11c71f4936f6ce42810 for https://github.com/chronosacaria/MCDungeonsArmors/issues/3 does not solve all crash issues.

Players are not the only `LivingEntity` that can drink potions (e.g. Wandering Traders, Witches) and any of the three mixins `FoodReservesEnchantmentMixin`, `PotionBarrierEnchantmentMixin` or `SurpriseGiftEnchantmentMixin` will cause a game crashing `ClassCastException` if they do - now that is one OP potion effect.

The fix is a simple `instanceof` test.
I haven't actually tested the fix, but it's so straight forward there really is no need.

Also, I would suggest combining these 3 mixins into one, as there's no reason to mixin into the same method of the same class 3 different times - except if you plan to conditionally disable mixins.